### PR TITLE
feat: add automated release workflow with BigWigs Packager

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Package and release
+        uses: BigWigsMods/packager@v2
+        with:
+          args: -g ${{ github.ref_name }}
+        env:
+          CF_API_KEY: ${{ secrets.CF_API_KEY }}
+          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
+          # Optional: Uncomment and add secrets when ready to use
+          # WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
+          # WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}


### PR DESCRIPTION
## Description
Adds GitHub Actions workflow to automate addon packaging and distribution using BigWigs Packager, the industry standard for WoW addon releases.

## Changes
- Create release.yml workflow triggered by version tags (v*)
- Use BigWigsMods/packager@v2 for automatic packaging
- Configure distribution to:
  - **CurseForge** (Project ID: 980904) - requires CF_API_KEY secret
  - **GitHub Releases** - uses GITHUB_TOKEN automatically
  - **WoWInterface** - optional, requires WOWI_API_TOKEN secret
  - **Wago** - optional, requires WAGO_API_TOKEN secret

## Setup Required (Post-Merge)
After merging, you'll need to:
1. Generate CurseForge API key at https://wow.curseforge.com/account/api-tokens
2. Add it to repository secrets as `CF_API_KEY`
3. (Optional) Add `WOWI_API_TOKEN` for WoWInterface distribution
4. (Optional) Add `WAGO_API_TOKEN` for Wago distribution

## Usage
Once configured, simply push a version tag:
```bash
git tag v1.0.3-alpha
git push origin v1.0.3-alpha
```

The workflow will automatically:
- Package the addon using pkgmeta.yaml rules
- Create a GitHub Release
- Upload to CurseForge
- Upload to optional platforms if configured

Closes #8